### PR TITLE
mqtt_client.dart: "Null check operator used on a null value" for authenticationManager in connect() method.

### DIFF
--- a/lib/src/mqtt_client.dart
+++ b/lib/src/mqtt_client.dart
@@ -244,6 +244,7 @@ class MqttClient {
     connectionHandler.onAutoReconnect = onAutoReconnect;
     publishingManager =
         MqttPublishingManager(connectionHandler, clientEventBus);
+    authenticationManager ??= MqttAuthenticationManager();
     authenticationManager!.connectionHandler = connectionHandler;
     subscriptionsManager =
         MqttSubscriptionManager(connectionHandler, clientEventBus);


### PR DESCRIPTION
When an active connection to the MQTT server is lost. The _disconnect() method sets the authenticationManager to null. 
When you call connect() again on the client, you get an exception "Null check operator used on a null value". 
With this extra line of code, the authenticationManager has an object for sure.

```
Class MQTT {
  ....
  
  Future<MqttConnectionStatus?> connect() async {
    return client.connect(user, pass);
  }
  
  ...
}
```

```
...
FloatingActionButton(
  child: Icon(Icons.message),
  onPressed: () async {
      await mqtt.connect(); //<- here you get the exception when pressing the button when the MQTT is back online.
      mqtt.sub();
  }
)
....
```