### PR TITLE
LateInitializationError: Field 'messageStream' has not been initialized.

### DIFF
--- a/lib/src/connectionhandling/browser/mqtt_browser_ws_connection.dart
+++ b/lib/src/connectionhandling/browser/mqtt_browser_ws_connection.dart
@@ -50,7 +50,6 @@ class MqttBrowserWsConnection extends MqttBrowserConnection {
       // Connect and save the socket.
       client = WebSocket(uriString, protocols);
       client.binaryType = 'arraybuffer';
-      messageStream = MqttByteBuffer(typed.Uint8Buffer());
       var closeEvents;
       var errorEvents;
       client.onOpen.listen((e) {
@@ -114,7 +113,6 @@ class MqttBrowserWsConnection extends MqttBrowserConnection {
       // Connect and save the socket.
       client = WebSocket(uriString, protocols);
       client.binaryType = 'arraybuffer';
-      messageStream = MqttByteBuffer(typed.Uint8Buffer());
       var closeEvents;
       var errorEvents;
       client.onOpen.listen((e) {

--- a/lib/src/connectionhandling/mqtt_connection_base.dart
+++ b/lib/src/connectionhandling/mqtt_connection_base.dart
@@ -23,7 +23,7 @@ class MqttConnectionBase {
 
   /// The read wrapper
   @protected
-  MqttReadWrapper readWrapper = MqttReadWrapper();;
+  MqttReadWrapper readWrapper = MqttReadWrapper();
 
   ///The read buffer
   @protected

--- a/lib/src/connectionhandling/mqtt_connection_base.dart
+++ b/lib/src/connectionhandling/mqtt_connection_base.dart
@@ -23,11 +23,11 @@ class MqttConnectionBase {
 
   /// The read wrapper
   @protected
-  MqttReadWrapper? readWrapper;
+  MqttReadWrapper readWrapper = MqttReadWrapper();;
 
   ///The read buffer
   @protected
-  late MqttByteBuffer messageStream;
+  MqttByteBuffer messageStream = MqttByteBuffer(typed.Uint8Buffer());
 
   /// Unsolicited disconnection callback
   @protected

--- a/lib/src/connectionhandling/server/mqtt_server_normal_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_normal_connection.dart
@@ -28,8 +28,6 @@ class MqttServerNormalConnection extends MqttServerConnection {
       // Connect and save the socket.
       Socket.connect(server, port).then((dynamic socket) {
         client = socket;
-        readWrapper = MqttReadWrapper();
-        messageStream = MqttByteBuffer(typed.Uint8Buffer());
         _startListening();
         completer.complete();
       }).catchError((dynamic e) {
@@ -54,8 +52,6 @@ class MqttServerNormalConnection extends MqttServerConnection {
       // Connect and save the socket.
       Socket.connect(server, port).then((dynamic socket) {
         client = socket;
-        readWrapper ??= MqttReadWrapper();
-        messageStream = MqttByteBuffer(typed.Uint8Buffer());
         _startListening();
         completer.complete();
       }).catchError((dynamic e) {

--- a/lib/src/connectionhandling/server/mqtt_server_normal_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_normal_connection.dart
@@ -54,6 +54,8 @@ class MqttServerNormalConnection extends MqttServerConnection {
       // Connect and save the socket.
       Socket.connect(server, port).then((dynamic socket) {
         client = socket;
+        readWrapper ??= MqttReadWrapper();
+        messageStream = MqttByteBuffer(typed.Uint8Buffer());
         _startListening();
         completer.complete();
       }).catchError((dynamic e) {

--- a/lib/src/connectionhandling/server/mqtt_server_secure_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_secure_connection.dart
@@ -80,6 +80,8 @@ class MqttServerSecureConnection extends MqttServerConnection {
         MqttLogger.log(
             'MqttServerSecureConnection::connectAuto - securing socket');
         client = socket;
+        readWrapper ??= MqttReadWrapper();
+        messageStream = MqttByteBuffer(typed.Uint8Buffer());
         MqttLogger.log(
             'MqttServerSecureConnection::connectAuto - start listening');
         _startListening();

--- a/lib/src/connectionhandling/server/mqtt_server_secure_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_secure_connection.dart
@@ -38,8 +38,6 @@ class MqttServerSecureConnection extends MqttServerConnection {
           .then((SecureSocket socket) {
         MqttLogger.log('MqttServerSecureConnection::connect - securing socket');
         client = socket;
-        readWrapper = MqttReadWrapper();
-        messageStream = MqttByteBuffer(typed.Uint8Buffer());
         MqttLogger.log('MqttServerSecureConnection::connect - start listening');
         _startListening();
         completer.complete();
@@ -80,8 +78,6 @@ class MqttServerSecureConnection extends MqttServerConnection {
         MqttLogger.log(
             'MqttServerSecureConnection::connectAuto - securing socket');
         client = socket;
-        readWrapper ??= MqttReadWrapper();
-        messageStream = MqttByteBuffer(typed.Uint8Buffer());
         MqttLogger.log(
             'MqttServerSecureConnection::connectAuto - start listening');
         _startListening();

--- a/lib/src/connectionhandling/server/mqtt_server_ws2_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_ws2_connection.dart
@@ -145,8 +145,6 @@ class MqttServerWs2Connection extends MqttServerConnection {
               _DetachedSocket(
                   socket, _subscription as StreamSubscription<Uint8List>?),
               serverSide: false);
-          readWrapper = MqttReadWrapper();
-          messageStream = MqttByteBuffer(typed.Uint8Buffer());
           MqttLogger.log('MqttServerWs2Connection::connect - start listening');
           _startListening();
           completer.complete();
@@ -212,8 +210,6 @@ class MqttServerWs2Connection extends MqttServerConnection {
               _DetachedSocket(
                   socket, _subscription as StreamSubscription<Uint8List>?),
               serverSide: false);
-          readWrapper ??= MqttReadWrapper();
-          messageStream = MqttByteBuffer(typed.Uint8Buffer());
           MqttLogger.log(
               'MqttServerWs2Connection::connectAuto - start listening');
           _startListening();

--- a/lib/src/connectionhandling/server/mqtt_server_ws2_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_ws2_connection.dart
@@ -212,6 +212,8 @@ class MqttServerWs2Connection extends MqttServerConnection {
               _DetachedSocket(
                   socket, _subscription as StreamSubscription<Uint8List>?),
               serverSide: false);
+          readWrapper ??= MqttReadWrapper();
+          messageStream = MqttByteBuffer(typed.Uint8Buffer());
           MqttLogger.log(
               'MqttServerWs2Connection::connectAuto - start listening');
           _startListening();

--- a/lib/src/connectionhandling/server/mqtt_server_ws_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_ws_connection.dart
@@ -100,6 +100,8 @@ class MqttServerWsConnection extends MqttServerConnection {
               protocols: protocols.isNotEmpty ? protocols : null)
           .then((dynamic socket) {
         client = socket;
+        readWrapper ??= MqttReadWrapper();
+        messageStream = MqttByteBuffer(typed.Uint8Buffer());
         _startListening();
         completer.complete();
       }).catchError((dynamic e) {

--- a/lib/src/connectionhandling/server/mqtt_server_ws_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_ws_connection.dart
@@ -52,8 +52,6 @@ class MqttServerWsConnection extends MqttServerConnection {
               protocols: protocols.isNotEmpty ? protocols : null)
           .then((dynamic socket) {
         client = socket;
-        readWrapper = MqttReadWrapper();
-        messageStream = MqttByteBuffer(typed.Uint8Buffer());
         _startListening();
         completer.complete();
       }).catchError((dynamic e) {
@@ -100,8 +98,6 @@ class MqttServerWsConnection extends MqttServerConnection {
               protocols: protocols.isNotEmpty ? protocols : null)
           .then((dynamic socket) {
         client = socket;
-        readWrapper ??= MqttReadWrapper();
-        messageStream = MqttByteBuffer(typed.Uint8Buffer());
         _startListening();
         completer.complete();
       }).catchError((dynamic e) {

--- a/lib/src/mqtt_client.dart
+++ b/lib/src/mqtt_client.dart
@@ -242,6 +242,7 @@ class MqttClient {
     connectionHandler.onDisconnected = internalDisconnect;
     connectionHandler.onConnected = onConnected;
     connectionHandler.onAutoReconnect = onAutoReconnect;
+    connectionHandler.onAutoReconnected = onAutoReconnected;
     publishingManager =
         MqttPublishingManager(connectionHandler, clientEventBus);
     authenticationManager ??= MqttAuthenticationManager();


### PR DESCRIPTION
When you have a Dart program which starts and connects to a MQTT broker. But the broker is offline, so you start the autoConnect proces.

```
try {
  await mqtt.connect();
  mqtt.sub();
} catch (e) {
  mqtt.client.doAutoReconnect();
}
```

When the MQTT broker is back online, it connects. But an exception is thrown because the messageStream isn't initialized. The late property is only set in the connect() method and should also be set in the connectAuto().

The mqtt_browser_ws_connection.dart is correct. The mqtt_server_*_connection.dart not.

Also the event handler onAutoReconnected isn't set and by this never called.

```
client.onAutoReconnected = () {
  if(client.subscriptionsManager!.subscriptions.isEmpty) {
    //initialize the subscriptions
  }
};
```