### PR TITLE
fix: future of connectAuto can be null

### DIFF
--- a/lib/src/connectionhandling/browser/mqtt_browser_ws_connection.dart
+++ b/lib/src/connectionhandling/browser/mqtt_browser_ws_connection.dart
@@ -86,8 +86,8 @@ class MqttBrowserWsConnection extends MqttBrowserConnection {
 
   /// Connect auto
   @override
-  Future<MqttConnectionStatus> connectAuto(String server, int port) {
-    final completer = Completer<MqttConnectionStatus>();
+  Future<MqttConnectionStatus?> connectAuto(String server, int port) {
+    final completer = Completer<MqttConnectionStatus?>();
     // Add the port if present
     Uri uri;
     try {


### PR DESCRIPTION
This request deals with the successful reconnect functionality of the Browser WS Connection. 

If the onOpen function of the Websocket receives the correct data the completer finishes with a null value. This threw an error as the return function was non-nullable. In the Server WS Connection, this is handled correctly.