### PR TITLE
Do not clear messageStream, was loosing messages.

### DIFF
--- a/lib/src/connectionhandling/browser/mqtt_browser_connection.dart
+++ b/lib/src/connectionhandling/browser/mqtt_browser_connection.dart
@@ -94,8 +94,6 @@ class MqttBrowserConnection extends MqttConnectionBase {
       if (messageIsValid) {
         MqttLogger.log(
             'MqttBrowserConnection::_onData - MESSAGE RECEIVED -> ', msg);
-        // If we have received a valid message we must clear the stream.
-        messageStream.clear();
         if (!clientEventBus!.streamController.isClosed) {
           if (msg!.header!.messageType == MqttMessageType.connectAck) {
             clientEventBus!.fire(MqttConnectAckMessageAvailable(msg));
@@ -105,6 +103,7 @@ class MqttBrowserConnection extends MqttConnectionBase {
           MqttLogger.log(
               'MqttBrowserConnection::_onData - message available event fired');
         } else {
+          messageStream.clear();
           MqttLogger.log(
               'MqttBrowserConnection::_onData - message not processed, disconnecting');
         }

--- a/lib/src/connectionhandling/server/mqtt_server_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_connection.dart
@@ -79,8 +79,6 @@ class MqttServerConnection extends MqttConnectionBase {
       if (messageIsValid) {
         MqttLogger.log(
             'MqttServerConnection::_onData - MESSAGE RECEIVED -> ', msg);
-        // If we have received a valid message we must clear the stream.
-        messageStream.clear();
         if (!clientEventBus!.streamController.isClosed) {
           if (msg!.header!.messageType == MqttMessageType.connectAck) {
             clientEventBus!.fire(MqttConnectAckMessageAvailable(msg));
@@ -90,6 +88,7 @@ class MqttServerConnection extends MqttConnectionBase {
           MqttLogger.log(
               'MqttServerConnection::_onData - message available event fired');
         } else {
+          messageStream.clear();
           MqttLogger.log(
               'MqttServerConnection::_onData - WARN - message available event not fired, event bus is closed');
         }


### PR DESCRIPTION
Our situation is that we are sending messages pretty often and we were loosing
received messages. I could see that the package on the network and then traced
it into this part where messageStream actually contained more than one message
and only first was actually handled.

I moved the clear() into the else part as it seemed to help when reconnecting.

Note. Why was sending a lot causing this? There is a lot of ack's being received and the sent message gets aggregated with one or more ack's. 