### PR TITLE
issue48 - downgraded path to 1.8.2 and meta to 1.8.0 for support of flutter stable

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,9 +13,9 @@ funding:
 dependencies:
  typed_data: '^1.3.1'
  event_bus: '^2.0.0'
- path: '^1.8.3'
+ path: '^1.8.2'
  crypto: '^3.0.2'
- meta: '^1.9.0'
+ meta: '^1.8.0'
  
 dev_dependencies:
  test: '^1.23.1'


### PR DESCRIPTION
Downgraded the path and meta version to make the package compatible with flutter stable version 3.7.x