### PR TITLE
-- mqtt协议解析剩余长度判断不一致，导致解析异常connection 断连

### DIFF
--- a/lib/src/utility/mqtt_byte_buffer.dart
+++ b/lib/src/utility/mqtt_byte_buffer.dart
@@ -84,10 +84,11 @@ class MqttByteBuffer {
     var position = _position;
     var header = MqttHeader.fromByteBuffer(this);
     // Restore the position
+    final avibytes = availableBytes; // should same in MqttMessage.createFrom
     _position = position;
-    if (availableBytes < header.messageSize) {
+    if (avibytes < header.messageSize) {
       MqttLogger.log(
-          'MqttByteBuffer:isMessageAvailable - Available bytes($availableBytes) is less than the message size'
+          'MqttByteBuffer:isMessageAvailable - Available bytes($avibytes) is less than the message size'
           ' ${header.messageSize}');
 
       return false;


### PR DESCRIPTION
MQTT protocol parsing remaining length judgment is inconsistent, resulting in parsing exception connection disconnection