### PR TITLE
fix(lib/mqtt5_browser_client): switch dart:html to universal_html

### DIFF
--- a/lib/mqtt5_browser_client.dart
+++ b/lib/mqtt5_browser_client.dart
@@ -8,7 +8,7 @@
 library mqtt5_browser_client;
 
 import 'dart:async';
-import 'dart:html';
+import 'package:universal_html/html.dart';
 import 'dart:typed_data';
 import 'package:event_bus/event_bus.dart' as events;
 import 'mqtt5_client.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
  typed_data: '^1.3.2'
  event_bus: '^2.0.0'
  path: '^1.8.2'
+ universal_html: '^2.2.4'
  crypto: '^3.0.3'
  meta: '^1.9.1'
  


### PR DESCRIPTION
Port over change from https://github.com/shamblett/mqtt_client/commit/d7eec87d5f151e09d006fab73a68346202d31719

Closes #85 