### PR TITLE
Refactor connection handling and add support for WebSocket

### DIFF
--- a/lib/mqtt5_client.dart
+++ b/lib/mqtt5_client.dart
@@ -9,6 +9,7 @@ library mqtt5_client;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 import 'package:meta/meta.dart';
 import 'package:typed_data/typed_data.dart' as typed;

--- a/lib/src/connectionhandling/mqtt_connection_base.dart
+++ b/lib/src/connectionhandling/mqtt_connection_base.dart
@@ -76,10 +76,27 @@ class MqttConnectionBase {
   void _disconnect() {
     // On disconnect clean(discard) anything in the message stream
     messageStream.clean();
-    if (client != null) {
-      client.destroy();
-      client = null;
+
+    // Close the client
+    if (client == null) {
+      return;
     }
+
+    if (client is WebSocket) {
+      final wsClient = client as WebSocket;
+      wsClient.close();
+    } else if (client is Socket) {
+      final socketClient = client as Socket;
+      socketClient.destroy();
+    } else {
+      try {
+        client.destroy();
+      } catch (e) {
+        MqttLogger.log('MqttConnectionBase::_disconnect - exception raised $e');
+      }
+    }
+
+    client = null;
   }
 
   /// User requested or auto disconnect disconnection


### PR DESCRIPTION
Fixes #111 

This commit refactors the connection handling in the `mqtt_connection_base.dart` file. It introduces support for WebSocket connections by importing the `dart:io` library. The `_disconnect()` method has been modified to close the client properly based on its type. If the client is a WebSocket, it is closed using the `close()` method. If it is a Socket, it is destroyed using the `destroy()` method. For other types of clients, the `destroy()` method is called. This change improves the overall connection handling in the MQTT client.