### PR TITLE
Keep subscription options and userProperties on resubscribe

### DIFF
--- a/lib/src/mqtt_subscription_manager.dart
+++ b/lib/src/mqtt_subscription_manager.dart
@@ -269,7 +269,9 @@ class MqttSubscriptionManager {
   void resubscribe() {
     for (final subscription in subscriptions.values) {
       _createNewSubscription(
-          subscription.topic.rawTopic, subscription.maximumQos);
+          subscription.topic.rawTopic, subscription.maximumQos,
+          userProperties: subscription.userProperties,
+          option: subscription.option);
     }
     subscriptions.clear();
   }
@@ -394,7 +396,9 @@ class MqttSubscriptionManager {
           'MttSubscriptionManager::_resubscribe - resubscribing from auto reconnect ${resubscribeEvent.fromAutoReconnect}');
       for (final subscription in subscriptions.values) {
         _createNewSubscription(
-            subscription.topic.rawTopic, subscription.maximumQos);
+            subscription.topic.rawTopic, subscription.maximumQos,
+            userProperties: subscription.userProperties,
+            option: subscription.option);
       }
       subscriptions.clear();
     } else {


### PR DESCRIPTION
Subscription options would be lost on autoreconnect-autoresubscribe or manual call to `resubscribe()`

Fixes #114 