### PR TITLE
Version 4.6 uses Path ^1.9.1 which conflicts with stable branch

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ funding:
 dependencies:
  typed_data: '^1.4.0'
  event_bus: '^2.0.1'
- path: '^1.9.1'
+ path: '^1.9.0'
  universal_html: '^2.2.4'
  crypto: '^3.0.6'
  meta: '^1.16.0'


### PR DESCRIPTION
Fixes #119