### PR TITLE
Add support for self signed certificates in websocket based connections

### DIFF
--- a/lib/src/connectionhandling/server/mqtt_server_ws2_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_ws2_connection.dart
@@ -105,6 +105,10 @@ class MqttServerWs2Connection extends MqttServerConnection {
     connect(server, port);
   }
 
+  /// Callback function to handle bad certificate (like self signed).
+  /// if true, ignore the error.
+  bool Function(X509Certificate certificate)? onBadCertificate;
+
   /// The websocket subprotocol list
   List<String> protocols = MqttConstants.protocolsMultipleDefault;
 
@@ -138,7 +142,8 @@ class MqttServerWs2Connection extends MqttServerConnection {
         'MqttServerWs2Connection:: WS URL is $uriString, protocols are $protocols');
 
     try {
-      SecureSocket.connect(uri.host, uri.port, context: context)
+      SecureSocket.connect(uri.host, uri.port,
+              context: context, onBadCertificate: onBadCertificate)
           .then((Socket socket) {
         MqttLogger.log('MqttServerWs2Connection::connect - securing socket');
         _performWSHandshake(socket, uri).then((bool b) {

--- a/lib/src/connectionhandling/server/mqtt_synchronous_server_connection_handler.dart
+++ b/lib/src/connectionhandling/server/mqtt_synchronous_server_connection_handler.dart
@@ -58,6 +58,7 @@ class MqttSynchronousServerConnectionHandler
           if (websocketProtocols != null) {
             connection.protocols = websocketProtocols;
           }
+          connection.onBadCertificate = onBadCertificate;
         } else if (secure) {
           MqttLogger.log(
               'MqttSynchronousServerConnectionHandler::internalConnect - '

--- a/lib/src/mqtt_server_client.dart
+++ b/lib/src/mqtt_server_client.dart
@@ -93,8 +93,8 @@ class MqttServerClient extends MqttClient {
       connectionHandler.useWebSocket = false;
       connectionHandler.useAlternateWebSocketImplementation = false;
       connectionHandler.securityContext = securityContext;
-      connectionHandler.onBadCertificate = onBadCertificate;
     }
+    connectionHandler.onBadCertificate = onBadCertificate;
     return await super.connect(username, password);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,10 +13,10 @@ funding:
 dependencies:
  typed_data: '^1.4.0'
  event_bus: '^2.0.1'
- path: '^1.9.1'
+ path: '^1.9.0'
  universal_html: '^2.2.4'
  crypto: '^3.0.6'
- meta: '^1.16.0'
+ meta: '^1.15.0'
  web: '>=0.5.0 <2.0.0'
  
 dev_dependencies:


### PR DESCRIPTION
The `onBadCertificate` callback allows the clients to accept self signed certificates that they receive from the server. It is currently implemented only for TCP based connections, not websockets. This patch passes the onBadCertificate callback to the underlying socket layer in case of websocket connections, enabling clients to accept self signed certificates in websocket based connections as well.