### PR TITLE
Expose the MqttConnectReasonCode in the MqttNoConnectionException #150

### DIFF
--- a/lib/src/connectionhandling/browser/mqtt_synchronous_browser_connection_handler.dart
+++ b/lib/src/connectionhandling/browser/mqtt_synchronous_browser_connection_handler.dart
@@ -105,13 +105,15 @@ class MqttSynchronousBrowserConnectionHandler
                 'The maximum allowed connection attempts '
                 '({$maxConnectionAttempts}) were exceeded. '
                 'The broker is not responding to the connection request message '
-                '(Missing Connection Acknowledgement?');
+                '(Missing Connection Acknowledgement?',
+                reasonCode: connectionStatus.reasonCode);
           } else {
             throw MqttNoConnectionException(
                 'The maximum allowed connection attempts '
                 '({$maxConnectionAttempts}) were exceeded. '
                 'The broker is not responding to the connection request message correctly '
-                'The reason code is ${connectionStatus.reasonCode}');
+                'The reason code is ${connectionStatus.reasonCode}',
+                reasonCode: connectionStatus.reasonCode);
           }
         } else {
           connectionStatus.state = MqttConnectionState.faulted;

--- a/lib/src/connectionhandling/server/mqtt_synchronous_server_connection_handler.dart
+++ b/lib/src/connectionhandling/server/mqtt_synchronous_server_connection_handler.dart
@@ -155,13 +155,15 @@ class MqttSynchronousServerConnectionHandler
                 'The maximum allowed connection attempts '
                 '({$maxConnectionAttempts}) were exceeded. '
                 'The broker is not responding to the connection request message '
-                '(Missing Connection Acknowledgement?');
+                '(Missing Connection Acknowledgement?',
+                reasonCode: connectionStatus.reasonCode);
           } else {
             throw MqttNoConnectionException(
                 'The maximum allowed connection attempts '
                 '({$maxConnectionAttempts}) were exceeded. '
                 'The broker is not responding to the connection request message correctly '
-                'The reason code is ${connectionStatus.reasonCode}');
+                'The reason code is ${connectionStatus.reasonCode}',
+                reasonCode: connectionStatus.reasonCode);
           }
         } else {
           connectionStatus.state = MqttConnectionState.faulted;

--- a/lib/src/exception/mqtt_noconnection_exception.dart
+++ b/lib/src/exception/mqtt_noconnection_exception.dart
@@ -10,11 +10,12 @@ part of '../../mqtt5_client.dart';
 /// Exception thrown when the client fails to connect
 class MqttNoConnectionException implements Exception {
   /// Construct
-  MqttNoConnectionException(String message) {
+  MqttNoConnectionException(String message, {this.reasonCode}) {
     _message = 'mqtt-client::NoConnectionException: $message';
   }
 
   late String _message;
+  final MqttConnectReasonCode? reasonCode;
 
   @override
   String toString() => _message;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
  typed_data: '^1.4.0'
  event_bus: '^2.0.1'
  path: '^1.9.0'
- universal_html: '^2.2.4'
  crypto: '^3.0.6'
  meta: '^1.15.0'
  web: '>=0.5.0 <2.0.0'


### PR DESCRIPTION
You could probably include new MqttConnectReasonCodes such as invalidUri, but for now this exposes the reason code from the MqttConnectAckMessage.

Also removed the universal_html package since it is not being used since adding WASM support.