### PR TITLE
Handle onBadCertificate in WS auto connect

### DIFF
--- a/lib/src/connectionhandling/mqtt_connection_keep_alive.dart
+++ b/lib/src/connectionhandling/mqtt_connection_keep_alive.dart
@@ -105,7 +105,8 @@ class MqttConnectionKeepAlive {
       }
     } else {
       MqttLogger.log(
-        'MqttConnectionKeepAlive::pingRequired - NOT sending ping - not connected',
+        'MqttConnectionKeepAlive::pingRequired - NOT sending ping - '
+        'state is not connected (${_connectionHandler.connectionStatus.state})',
       );
     }
     MqttLogger.log(

--- a/lib/src/connectionhandling/server/mqtt_server_ws2_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_ws2_connection.dart
@@ -234,9 +234,12 @@ class MqttServerWs2Connection extends MqttServerConnection {
     );
 
     try {
-      SecureSocket.connect(uri.host, uri.port, context: context).then((
-        Socket socket,
-      ) {
+      SecureSocket.connect(
+        uri.host,
+        uri.port,
+        context: context,
+        onBadCertificate: onBadCertificate,
+      ).then((Socket socket) {
         MqttLogger.log(
           'MqttServerWs2Connection::connectAuto - securing socket',
         );

--- a/lib/src/connectionhandling/server/mqtt_server_ws_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_ws_connection.dart
@@ -37,29 +37,43 @@ class MqttServerWsConnection extends MqttServerConnection {
   /// Connect
   @override
   Future<MqttConnectionStatus?> connect(String server, int port) {
+    return _connect(server: server, port: port, auto: false);
+  }
+
+  /// Connect Auto
+  @override
+  Future<MqttConnectionStatus?> connectAuto(String server, int port) {
+    return _connect(server: server, port: port, auto: true);
+  }
+
+  Future<MqttConnectionStatus?> _connect({
+    required String server,
+    required int port,
+    required bool auto,
+  }) {
     final completer = Completer<MqttConnectionStatus?>();
-    MqttLogger.log('MqttWsConnection::connectAuto - entered');
+    final ctx = auto ? 'connectAuto' : 'connect';
+    MqttLogger.log('MqttWsConnection::$ctx - entered');
     // Add the port if present
     Uri uri;
     try {
       uri = Uri.parse(server);
     } on Exception catch (_, stack) {
       final message =
-          'MqttWsConnection::The URI supplied for the WS '
+          'MqttWsConnection::$ctx - The URI supplied for the WS '
           'connection is not valid - $server';
       Error.throwWithStackTrace(MqttNoConnectionException(message), stack);
     }
     if (uri.scheme != 'ws' && uri.scheme != 'wss') {
       final message =
-          'MqttWsConnection::The URI supplied for the WS has '
-          'an incorrect scheme - $server';
+          'MqttWsConnection::$ctx - The URI supplied for the WS '
+          'has an incorrect scheme - $server';
       throw MqttNoConnectionException(message);
     }
     uri = uri.replace(port: port);
-
     final uriString = uri.toString();
     MqttLogger.log(
-      'MqttWsConnection:: WS URL is $uriString, protocols are $protocols',
+      'MqttWsConnection::$ctx - WS URL is $uriString, protocols are $protocols',
     );
     HttpClient? httpClient;
     if (onBadCertificate != null) {
@@ -81,63 +95,15 @@ class MqttServerWsConnection extends MqttServerConnection {
             completer.complete();
           })
           .catchError((dynamic e) {
+            MqttLogger.log(
+              'MqttWsConnection::$ctx - WebSocket.connect error $e',
+            );
             onError(e);
             completer.completeError(e);
           });
     } on Exception catch (_, stack) {
       final message =
-          'MqttWsConnection::The connection to the message broker '
-          '{$uriString} could not be made.';
-      Error.throwWithStackTrace(MqttNoConnectionException(message), stack);
-    }
-    return completer.future;
-  }
-
-  /// Connect Auto
-  @override
-  Future<MqttConnectionStatus?> connectAuto(String server, int port) {
-    final completer = Completer<MqttConnectionStatus?>();
-    MqttLogger.log('MqttWsConnection::connectAuto - entered');
-    // Add the port if present
-    Uri uri;
-    try {
-      uri = Uri.parse(server);
-    } on Exception catch (_, stack) {
-      final message =
-          'MqttWsConnection::connectAuto - The URI supplied for the WS '
-          'connection is not valid - $server';
-      Error.throwWithStackTrace(MqttNoConnectionException(message), stack);
-    }
-    if (uri.scheme != 'ws' && uri.scheme != 'wss') {
-      final message =
-          'MqttWsConnection::connectAuto - The URI supplied for the WS has '
-          'an incorrect scheme - $server';
-      throw MqttNoConnectionException(message);
-    }
-    uri = uri.replace(port: port);
-
-    final uriString = uri.toString();
-    MqttLogger.log(
-      'MqttWsConnection::connectAuto - WS URL is $uriString, protocols are $protocols',
-    );
-    try {
-      // Connect and save the socket.
-      WebSocket.connect(
-            uriString,
-            protocols: protocols.isNotEmpty ? protocols : null,
-          )
-          .then((dynamic socket) {
-            client = socket;
-            _startListening();
-            completer.complete();
-          })
-          .catchError((dynamic e) {
-            onError(e);
-            completer.completeError(e);
-          });
-    } on Exception catch (_, stack) {
-      final message =
-          'MqttWsConnection::connectAuto - The connection to the message broker '
+          'MqttWsConnection::$ctx - The connection to the message broker '
           '{$uriString} could not be made.';
       Error.throwWithStackTrace(MqttNoConnectionException(message), stack);
     }


### PR DESCRIPTION
onBadCertificate is not handled in connectAuto for web sockets; I missed this in #133. 

The `connect` and `connectAuto` functions in `MqttServerWsConnection` were the same except for log messages, so I have taken the liberty to implement it as a single function. If you would rather leave them as it is, I can revert that. 