### PR TITLE
Fix malformed disconnect frame after inbound parse errors

### DIFF
--- a/lib/src/connectionhandling/server/mqtt_server_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_server_connection.dart
@@ -153,7 +153,8 @@ class MqttServerConnection extends MqttConnectionBase {
       // Send disconnect
       final disconnect = MqttDisconnectMessage()
         ..withReasonCode(MqttDisconnectReasonCode.normalDisconnection);
-      messageStream.reset();
+      messageStream.seek(0);
+      messageStream.clear();
       disconnect.writeTo(messageStream);
       messageStream.seek(0);
       send(messageStream);

--- a/lib/src/messages/mqtt_header.dart
+++ b/lib/src/messages/mqtt_header.dart
@@ -112,7 +112,14 @@ class MqttHeader {
     // combination of message type, dup, qos and retain, and the
     // following bytes (up to 4 of them) are the size of the
     // payload + variable header.
-    final messageTypeLength = messageType!.index << 4;
+    final messageTypeIndex = messageType?.index;
+    if (messageTypeIndex == null ||
+        messageTypeIndex == MqttMessageType.reserved1.index) {
+      throw MqttInvalidHeaderException(
+        'Cannot build header bytes, message type is null or reserved1',
+      );
+    }
+    final messageTypeLength = messageTypeIndex << 4;
     final duplicateLength = (duplicate ? 1 : 0) << 3;
     final qosLength = qos.index << 1;
     final retainLength = retain ? 1 : 0;

--- a/lib/src/utility/mqtt_byte_buffer.dart
+++ b/lib/src/utility/mqtt_byte_buffer.dart
@@ -72,7 +72,7 @@ class MqttByteBuffer {
 
     // If we do not have 2 bytes we do not have a complete header, so no
     // message is available.
-    if (length < MqttConstants.minHeaderLength) {
+    if (availableBytes < MqttConstants.minHeaderLength) {
       return false;
     }
 
@@ -80,12 +80,16 @@ class MqttByteBuffer {
     // if the whole message is available.
 
     // If the first byte of the header is 0 then skip past it.
-    if (peekByte() == 0) {
+    if (peekByte() == 0 && availableBytes > 1) {
       MqttLogger.log(
         'MqttByteBuffer:isMessageAvailable - first header byte is zero, skipping',
       );
       _position++;
       shrink();
+    }
+
+    if (availableBytes < MqttConstants.minHeaderLength) {
+      return false;
     }
 
     // Assume we now have a valid header

--- a/test/mqtt_client_base_test.dart
+++ b/test/mqtt_client_base_test.dart
@@ -882,6 +882,14 @@ void main() {
       buff1.seek(20);
       expect(buff1.position, 10);
     });
+    test(
+      'Byte Buffer message availability with a single zero byte remaining',
+      () {
+        final buff = MqttByteBuffer.fromList([0x10, 0x00]);
+        buff.seek(1);
+        expect(buff.isMessageAvailable(), isFalse);
+      },
+    );
     test('Sleep Async', () async {
       final start = DateTime.now();
       await MqttUtilities.asyncSleep(1);

--- a/test/mqtt_client_message_test.dart
+++ b/test/mqtt_client_message_test.dart
@@ -162,6 +162,14 @@ void main() {
       final header = MqttHeader().asType(MqttMessageType.publishComplete);
       expect(header.messageType, MqttMessageType.publishComplete);
     });
+    test('Header bytes rejects unset message type', () {
+      final header = MqttHeader();
+      expect(header.headerBytes, throwsA(isA<MqttInvalidHeaderException>()));
+    });
+    test('Header bytes rejects reserved message type', () {
+      final header = MqttHeader().asType(MqttMessageType.reserved1);
+      expect(header.headerBytes, throwsA(isA<MqttInvalidHeaderException>()));
+    });
     test('Retain', () {
       final header = MqttHeader().shouldBeRetained();
       expect(header.retain, isTrue);

--- a/test/mqtt_server_connection_error_test.dart
+++ b/test/mqtt_server_connection_error_test.dart
@@ -1,0 +1,118 @@
+/*
+ * Package : mqtt5_client
+ * Author : S. Hamblett <steve.hamblett@linux.com>
+ * Date   : 10/05/2020
+ * Copyright :  S.Hamblett
+ */
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:mqtt5_client/mqtt5_client.dart';
+import 'package:mqtt5_client/mqtt5_server_client.dart';
+import 'package:test/test.dart';
+import 'package:typed_data/typed_buffers.dart';
+import 'support/mqtt_client_mock_socket.dart';
+
+class MqttMockSocketMalformedInbound extends MockSocket {
+  dynamic onDataFunc;
+  final writes = <List<int>>[];
+  bool initial = true;
+
+  static MqttMockSocketMalformedInbound? instance;
+
+  static Future<MqttMockSocketMalformedInbound> connect(
+    host,
+    int port, {
+    sourceAddress,
+    int sourcePort = 0,
+    Duration? timeout,
+  }) {
+    final completer = Completer<MqttMockSocketMalformedInbound>();
+    final extSocket = MqttMockSocketMalformedInbound();
+    extSocket.port = port;
+    extSocket.host = host;
+    instance = extSocket;
+    completer.complete(extSocket);
+    return completer.future;
+  }
+
+  @override
+  void add(List<int> data) {
+    writes.add(List<int>.from(data));
+    mockBytes.addAll(data);
+    if (initial) {
+      initial = false;
+      _sendConnectAck();
+    }
+  }
+
+  void emitMalformedConnectAck() {
+    onDataFunc(Uint8List.fromList([0x20, 0x03, 0x00, 0x00, 0xFF]));
+  }
+
+  @override
+  StreamSubscription<Uint8List> listen(
+    void Function(Uint8List event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    onDataFunc = onData;
+    return outgoing;
+  }
+
+  void _sendConnectAck() {
+    final ack = MqttConnectAckMessage()
+      ..withReasonCode(MqttConnectReasonCode.success);
+    final buff = Uint8Buffer();
+    final ms = MqttByteBuffer(buff);
+    ack.writeTo(ms);
+    ms.seek(0);
+    onDataFunc(Uint8List.fromList(ms.buffer!.toList()));
+  }
+}
+
+void main() {
+  test('Malformed inbound message sends a clean disconnect frame', () async {
+    await IOOverrides.runZoned(
+      () async {
+        final client = MqttServerClient(
+          'localhost',
+          'MqttMalformedInboundTest',
+          maxConnectionAttempts: 1,
+        );
+        client.connectionMessage = MqttConnectMessage().withClientIdentifier(
+          'MqttMalformedInboundTest',
+        );
+
+        final status = await client.connect();
+        expect(status?.state, MqttConnectionState.connected);
+
+        final socket = MqttMockSocketMalformedInbound.instance!;
+        socket.writes.clear();
+        socket.emitMalformedConnectAck();
+
+        expect(socket.writes.last, [0xE0, 0x00]);
+      },
+      socketConnect:
+          (
+            dynamic host,
+            int port, {
+            dynamic sourceAddress,
+            int sourcePort = 0,
+            Duration? timeout,
+          }) => MqttMockSocketMalformedInbound.connect(
+            host,
+            port,
+            sourceAddress: sourceAddress,
+            sourcePort: sourcePort,
+            timeout: timeout,
+          ),
+    );
+  });
+}


### PR DESCRIPTION
# Fix corrupted DISCONNECT frame on inbound parse failure

## Summary

This PR fixes a buffer corruption issue in `MqttServerConnection._onData()` that can cause the client to send a malformed DISCONNECT packet after an inbound message parsing error.

The core fix is to clear `messageStream` before serializing the DISCONNECT frame in the `_onData()` catch block. This prevents residual bytes from a failed inbound parse from being included in the outbound DISCONNECT packet.

## Problem

When `_onData()` catches an irrecoverable parsing exception, it currently attempts to send a normal DISCONNECT message:

```dart
messageStream.reset();
disconnect.writeTo(messageStream);
messageStream.seek(0);
send(messageStream);
```

`MqttByteBuffer.reset()` only resets the buffer position to `0`; it does not clear the underlying byte buffer.

If `messageStream` still contains bytes from a malformed or partially parsed inbound packet, `disconnect.writeTo(messageStream)` overwrites from position `0`, but `send(messageStream)` still sends `message.length`, which includes any residual bytes left after the newly written DISCONNECT frame.

This can result in corrupted outbound data being sent to the broker.

## Root Cause

`MqttServerConnection.send()` sends the full buffer length:

```dart
final length = message.length;
final messageBytes = message.read(length);
```

So after `reset()` + `disconnect.writeTo(...)`, old bytes still present in the buffer can remain part of the outgoing frame.

## Changes

### `mqtt_server_connection.dart`

Replaces `reset()` with `seek(0)` + `clear()` before writing the DISCONNECT message:

```dart
messageStream.seek(0);
messageStream.clear();
disconnect.writeTo(messageStream);
messageStream.seek(0);
send(messageStream);
```

This ensures the outbound DISCONNECT packet contains only the serialized DISCONNECT frame.

### `mqtt_header.dart`

Adds a defensive guard in `MqttHeader.headerBytes()` so headers cannot be serialized with:

- `messageType == null`
- `messageType == MqttMessageType.reserved1`

This prevents accidentally generating a fixed header with MQTT message type `0`, which is reserved and invalid for transmission.

This check only affects serialization. Existing header parsing behavior is unchanged.

### `mqtt_byte_buffer.dart`

Tightens `MqttByteBuffer.isMessageAvailable()` by:

- checking `availableBytes` rather than total `length`
- only skipping a leading zero byte when more than one byte is available
- re-checking header availability after the skip

This avoids a range error when the buffer position points at a single remaining `0x00` byte.

## Tests Added

This PR adds regression coverage for the affected paths:

- malformed inbound message handling sends a clean DISCONNECT frame
- `MqttHeader.headerBytes()` rejects null message types
- `MqttHeader.headerBytes()` rejects `reserved1`
- `MqttByteBuffer.isMessageAvailable()` safely handles a single remaining zero byte

The new connection regression test failed before the fix because the sent frame contained residual data before the DISCONNECT bytes. After the fix, it sends only:

```text
[0xE0, 0x00]
```

## Test Plan

Ran locally:

```bash
dart format --output=none --set-exit-if-changed .
dart analyze
dart test
dart run coverage:test_with_coverage
```

All passed.

## Compatibility

This change does not modify any public API signatures.

The main behavior change is limited to error handling and defensive validation during outbound header serialization.
