### PR TITLE
fix: make MqttClient.updates nullable after disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.17.2
+- Fix `MqttClient.updates` null-check crash when `subscriptionsManager` is null
+  after disconnect / reconnect races. `updates` is now nullable and consistent
+  with `published` (`subscriptionsManager?.subscriptionNotifier`).
+
 # 4.17.1
 - [PR 197](https://github.com/shamblett/mqtt5_client/pull/197)
 

--- a/example/aws_iot_certificates.dart
+++ b/example/aws_iot_certificates.dart
@@ -75,7 +75,7 @@ Future<int> main() async {
     // Subscribe to the same topic
     client.subscribe(topic, MqttQos.atLeastOnce);
     // Print incoming messages from another client on this topic
-    client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+    client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
       final recMess = c[0].payload as MqttPublishMessage;
       final pt = MqttPublishPayload.bytesToString(recMess.payload.message);
       print(

--- a/example/aws_iot_cognito_amplify.dart
+++ b/example/aws_iot_cognito_amplify.dart
@@ -200,7 +200,7 @@ Future<int> main() async {
     // Subscribe to the same topic
     client.subscribe(topic, MqttQos.atLeastOnce);
     // Print incoming messages from another client on this topic
-    client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+    client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
       final recMess = c[0].payload as MqttPublishMessage;
       final pt = MqttPublishPayload.bytesToStringAsString(
         recMess.payload.message!,

--- a/example/mqtt5_browser_client.dart
+++ b/example/mqtt5_browser_client.dart
@@ -92,7 +92,7 @@ Future<int> main() async {
 
   /// The client has a change notifier object(see the Observable class) which we then listen to to get
   /// notifications of published updates to each subscribed topic.
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
 

--- a/example/mqtt5_client_publish_qos1.dart
+++ b/example/mqtt5_client_publish_qos1.dart
@@ -58,7 +58,7 @@ Future<int> main() async {
   // Do not subscribe to this topic.
   const topic3 = 'SJHTopic3';
 
-  client.updates.listen((dynamic c) {
+  client.updates!.listen((dynamic c) {
     final MqttPublishMessage recMess = c[0].payload;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
     print(

--- a/example/mqtt5_client_publish_qos2.dart
+++ b/example/mqtt5_client_publish_qos2.dart
@@ -57,7 +57,7 @@ Future<int> main() async {
   client.subscribe(topic2, MqttQos.exactlyOnce);
 
   // ignore: avoid_annotating_with_dynamic
-  client.updates.listen((dynamic c) {
+  client.updates!.listen((dynamic c) {
     final MqttPublishMessage recMess = c[0].payload;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
     print(

--- a/example/mqtt5_server_client.dart
+++ b/example/mqtt5_server_client.dart
@@ -142,7 +142,7 @@ Future<int> main() async {
 
   /// The client has a change notifier object(see the Observable class) which we then listen to to get
   /// notifications of published updates to each subscribed topic.
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
 

--- a/example/mqtt5_server_client_autoreconnect.dart
+++ b/example/mqtt5_server_client_autoreconnect.dart
@@ -105,7 +105,7 @@ Future<int> main() async {
 
   /// The client has a change notifier object(see the Observable class) which we then listen to to get
   /// notifications of published updates to each subscribed topic.
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
 

--- a/example/mqtt5_server_client_keep_alive_defaults_to_disabled.dart
+++ b/example/mqtt5_server_client_keep_alive_defaults_to_disabled.dart
@@ -133,7 +133,7 @@ Future<int> main() async {
 
   /// The client has a change notifier object(see the Observable class) which we then listen to to get
   /// notifications of published updates to each subscribed topic.
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
 

--- a/example/mqtt5_server_client_keep_alive_disconnect.dart
+++ b/example/mqtt5_server_client_keep_alive_disconnect.dart
@@ -139,7 +139,7 @@ Future<int> main() async {
 
   /// The client has a change notifier object(see the Observable class) which we then listen to to get
   /// notifications of published updates to each subscribed topic.
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
 

--- a/example/mqtt5_server_client_secure.dart
+++ b/example/mqtt5_server_client_secure.dart
@@ -100,7 +100,7 @@ Future<int> main() async {
 
   /// The client has a change notifier object(see the Observable class) which we then listen to to get
   /// notifications of published updates to each subscribed topic.
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
 

--- a/example/mqtt5_server_client_websocket.dart
+++ b/example/mqtt5_server_client_websocket.dart
@@ -111,7 +111,7 @@ Future<int> main() async {
 
   /// The client has a change notifier object(see the Observable class) which we then listen to to get
   /// notifications of published updates to each subscribed topic.
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage?>>? c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage?>>? c) {
     final recMess = c![0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
 

--- a/example/mqtt5_server_client_websocket_secure.dart
+++ b/example/mqtt5_server_client_websocket_secure.dart
@@ -108,7 +108,7 @@ Future<int> main() async {
 
   /// The client has a change notifier object(see the Observable class) which we then listen to to get
   /// notifications of published updates to each subscribed topic.
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage?>>? c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage?>>? c) {
     final recMess = c![0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
 

--- a/lib/src/mqtt_client.dart
+++ b/lib/src/mqtt_client.dart
@@ -266,9 +266,13 @@ class MqttClient {
   @protected
   MqttEventBus? clientEventBus;
 
-  /// The stream on which all subscribed topic updates are published to
-  Stream<List<MqttReceivedMessage<MqttMessage>>> get updates =>
-      subscriptionsManager!.subscriptionNotifier;
+  /// The stream on which all subscribed topic updates are published to.
+  ///
+  /// Attach listeners only after connect has been called.
+  /// Returns null if the client is disconnected (subscriptions manager
+  /// has been cleared), matching [published].
+  Stream<List<MqttReceivedMessage<MqttMessage>>>? get updates =>
+      subscriptionsManager?.subscriptionNotifier;
 
   /// Common client connection method.
   Future<MqttConnectionStatus?> connect([

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: mqtt5_client
 description: A server and browser based MQTT5 client for Dart supporting normal, secure sockets and websockets.
-version: 4.17.1
-repository: https://github.com/shamblett/mqtt5_client
-homepage: https://github.com/shamblett/mqtt5_client
+version: 4.17.2
+repository: https://github.com/charles0122/mqtt5_client
+homepage: https://github.com/charles0122/mqtt5_client
 
 environment:
  sdk: '>=3.8.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: mqtt5_client
 description: A server and browser based MQTT5 client for Dart supporting normal, secure sockets and websockets.
 version: 4.17.2
-repository: https://github.com/charles0122/mqtt5_client
-homepage: https://github.com/charles0122/mqtt5_client
+repository: https://github.com/shamblett/mqtt5_client
+homepage: https://github.com/shamblett/mqtt5_client
 
 environment:
  sdk: '>=3.8.0 <4.0.0'

--- a/test/issues/issue110/issue110.dart
+++ b/test/issues/issue110/issue110.dart
@@ -115,7 +115,7 @@ Future<int> main() async {
 
   /// The client has a change notifier object(see the Observable class) which we then listen to to get
   /// notifications of published updates to each subscribed topic.
-  clientA.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  clientA.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
 

--- a/test/issues/issue168/main.dart
+++ b/test/issues/issue168/main.dart
@@ -30,7 +30,7 @@ void main() async {
       print('Connected successfully');
 
       // Now it's safe to listen
-      client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+      client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
         i++;
         print(i);
 

--- a/test/issues/issue22/recieve_retained_message.dart
+++ b/test/issues/issue22/recieve_retained_message.dart
@@ -21,7 +21,7 @@ Future<int> main() async {
     await MqttUtilities.asyncSleep(0);
 
     client.subscribe(topic, MqttQos.exactlyOnce);
-    client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+    client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
       final data = (c[0].payload as MqttPublishMessage).payload.message!;
       print("Recieved Message: $data at ${c[0].topic}");
       if (c[0].topic == topic) {
@@ -58,7 +58,7 @@ Future<int> main() async {
     await MqttUtilities.asyncSleep(1);
 
     client.subscribe(topic, MqttQos.exactlyOnce);
-    client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+    client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
       final data = (c[0].payload as MqttPublishMessage).payload.message!;
       print("Recieved Message: $data at ${c[0].topic}");
       if (c[0].topic == topic) {

--- a/test/issues/issue28/receiver_nosubscribe.dart
+++ b/test/issues/issue28/receiver_nosubscribe.dart
@@ -22,7 +22,7 @@ Future<int> main() async {
 
   // Listen for the counter messages
   print('ISSUE::Listening......');
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final payload = recMess.payload.message;
     if (payload != null) {

--- a/test/issues/issue28/receiver_reconnect.dart
+++ b/test/issues/issue28/receiver_reconnect.dart
@@ -27,7 +27,7 @@ Future<int> main() async {
 
   // Listen for the counter messages
   print('ISSUE::Listening......');
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final payload = recMess.payload.message;
     if (payload != null) {

--- a/test/issues/issue28/receiver_subscribe.dart
+++ b/test/issues/issue28/receiver_subscribe.dart
@@ -31,7 +31,7 @@ Future<int> main() async {
 
   // Listen for the counter messages
   print('ISSUE::Listening......');
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final payload = recMess.payload.message;
     if (payload != null) {

--- a/test/issues/issue28/receiver_subscribe_no_wait.dart
+++ b/test/issues/issue28/receiver_subscribe_no_wait.dart
@@ -26,7 +26,7 @@ Future<int> main() async {
 
   // Listen for the counter messages
   print('ISSUE::Listening......');
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final payload = recMess.payload.message;
     if (payload != null) {

--- a/test/issues/issue6/issue6-normal-disconnectedbroker.dart
+++ b/test/issues/issue6/issue6-normal-disconnectedbroker.dart
@@ -80,7 +80,7 @@ Future<int> main() async {
 
       // Listen for our responses.
       print('ISSUE: Listening >>>>');
-      final stream = client.updates
+      final stream = client.updates!
           .expand((event) sync* {
             for (var e in event) {
               MqttPublishMessage message = e.payload;

--- a/test/issues/issue6/issue6-normal-hive.dart
+++ b/test/issues/issue6/issue6-normal-hive.dart
@@ -66,7 +66,7 @@ Future<int> main() async {
 
     // Listen for our responses.
     print('ISSUE: Listening >>>>');
-    final stream = client.updates
+    final stream = client.updates!
         .expand((event) sync* {
           for (var e in event) {
             MqttPublishMessage message = e.payload;

--- a/test/issues/issue6/issue6-normal-mosquitto.dart
+++ b/test/issues/issue6/issue6-normal-mosquitto.dart
@@ -66,7 +66,7 @@ Future<int> main() async {
 
     // Listen for our responses.
     print('ISSUE: Listening >>>>');
-    final stream = client.updates
+    final stream = client.updates!
         .expand((event) sync* {
           for (var e in event) {
             MqttPublishMessage message = e.payload;

--- a/test/issues/issue6/issue6-secure-mosquitto.dart
+++ b/test/issues/issue6/issue6-secure-mosquitto.dart
@@ -77,7 +77,7 @@ Future<int> main() async {
 
     // Listen for our responses.
     print('ISSUE: Listening >>>>');
-    final stream = client.updates
+    final stream = client.updates!
         .expand((event) sync* {
           for (var e in event) {
             MqttPublishMessage message = e.payload;

--- a/test/issues/issue6/issue6-ws-mosquitto.dart
+++ b/test/issues/issue6/issue6-ws-mosquitto.dart
@@ -67,7 +67,7 @@ Future<int> main() async {
 
     // Listen for our responses.
     print('ISSUE: Listening >>>>');
-    final stream = client.updates
+    final stream = client.updates!
         .expand((event) sync* {
           for (var e in event) {
             MqttPublishMessage message = e.payload;

--- a/test/issues/issue6/issue6-wss-mosquitto.dart
+++ b/test/issues/issue6/issue6-wss-mosquitto.dart
@@ -71,7 +71,7 @@ Future<int> main() async {
 
       // Listen for our responses.
       print('ISSUE: Listening >>>>');
-      final stream = client.updates
+      final stream = client.updates!
           .expand((event) sync* {
             for (var e in event) {
               MqttPublishMessage message = e.payload;

--- a/test/mqtt_client_disconnection_test.dart
+++ b/test/mqtt_client_disconnection_test.dart
@@ -149,4 +149,52 @@ void main() {
           ),
     );
   });
+
+  test('Updates and published are null after disconnect', () async {
+    await IOOverrides.runZoned(
+      () async {
+        final client = MqttServerClient(
+          'localhost',
+          '',
+          maxConnectionAttempts: 1,
+        );
+        client.connectionMessage = MqttConnectMessage().withClientIdentifier(
+          'MqttUpdatesNullAfterDisconnect',
+        );
+        await client.connect();
+        expect(client.connectionStatus?.state, MqttConnectionState.connected);
+        expect(client.updates, isNotNull);
+        expect(client.published, isNotNull);
+
+        client.disconnect();
+        expect(
+          client.connectionStatus?.state,
+          MqttConnectionState.disconnected,
+        );
+        // Must not throw Null check operator used on a null value.
+        expect(client.updates, isNull);
+        expect(client.published, isNull);
+      },
+      socketConnect:
+          (
+            dynamic host,
+            int port, {
+            dynamic sourceAddress,
+            int sourcePort = 0,
+            Duration? timeout,
+          }) => MqttMockSocketDisconnectNormal.connect(
+            host,
+            port,
+            sourceAddress: sourceAddress,
+            sourcePort: sourcePort,
+            timeout: timeout,
+          ),
+    );
+  });
+
+  test('Updates is null before connect', () {
+    final client = MqttServerClient('localhost', 'pre-connect');
+    expect(client.updates, isNull);
+    expect(client.published, isNull);
+  });
 }

--- a/test/support/mqtt_client_broker_test_subscribe.dart
+++ b/test/support/mqtt_client_broker_test_subscribe.dart
@@ -25,7 +25,7 @@ Future<int> main() async {
   // Subscribe to a known topic
   const topic = 'test/hw';
   client.subscribe(topic, MqttQos.exactlyOnce);
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
     print('Change notification:: payload is <$pt> for topic <$topic>');

--- a/test/support/mqtt_client_broker_test_ws_subscribe.dart
+++ b/test/support/mqtt_client_broker_test_ws_subscribe.dart
@@ -28,7 +28,7 @@ Future<int> main() async {
   // Subscribe to a known topic
   const topic = 'test/hw';
   client.subscribe(topic, MqttQos.exactlyOnce);
-  client.updates.listen((List<MqttReceivedMessage<MqttMessage>> c) {
+  client.updates!.listen((List<MqttReceivedMessage<MqttMessage>> c) {
     final recMess = c[0].payload as MqttPublishMessage;
     final pt = MqttUtilities.bytesToStringAsString(recMess.payload.message!);
     print('Change notification:: payload is <$pt> for topic <$topic>');


### PR DESCRIPTION
Avoid Null check operator crash when subscriptionsManager is cleared during disconnect/reconnect races; align with published and bump to 4.17.2.